### PR TITLE
Fix useBackground flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ module.exports = attacher
 function attacher(options) {
   var settings = options || {}
   var theme = settings.theme || 'nord'
-  var useBackground = settings.useBackground || true
+  var useBackground =
+    typeof settings.useBackground === 'undefined'
+      ? true
+      : Boolean(settings.useBackground)
   var shikiTheme
   var highlighter
 


### PR DESCRIPTION
Proposed fix for #26 

Changes the handling of the value of the `useBackground` option.

If undefined, the option defaults to `true`. (same as existing behavior)

Otherwise uses boolean value of the option value. (fixed behavior)