### PR TITLE
Support shiki 0.2.4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/rsclarke/rehype-shiki#readme",
   "dependencies": {
     "hast-util-to-string": "^1.0.4",
-    "shiki": "^0.1.7",
-    "shiki-languages": "^0.1.6",
+    "shiki": "^0.2.4",
+    "shiki-languages": "^0.2.4",
     "unist-builder": "^2.0.3",
     "unist-util-visit": "^2.0.3"
   },


### PR DESCRIPTION
This pull request bumps the `shiki` and `shiki-languages` packages to version `^0.2.4`.